### PR TITLE
Don't create schema pointing to root folder

### DIFF
--- a/spark_utils/delta_lake/functions.py
+++ b/spark_utils/delta_lake/functions.py
@@ -95,7 +95,7 @@ def publish_delta_to_hive(
     """
 
     spark_session.sql(
-        f"CREATE SCHEMA IF NOT EXISTS {publish_schema_name} location 'abfss://{data_path[8:].split('/')[0]}/'"
+        f"CREATE SCHEMA IF NOT EXISTS {publish_schema_name} location 'abfss://{'/'.join(data_path[8:].split('/')[0:-1])}/'"
     )
     if refresh:
         spark_session.sql(f"DROP TABLE IF EXISTS {publish_schema_name}.{publish_table_name}")


### PR DESCRIPTION
Fixes #12 

Now the schema path will be based on the full path, except everything after the last `/`, assuming that this will be the table name