### PR TITLE
fix: remove -x from set -euxo pipefail to prevent secret leakage

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,7 +55,7 @@ jobs:
         env:
           PYSPARK_SUBMIT_ARGS: "--packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:1.10.0,org.apache.iceberg:iceberg-aws-bundle:1.10.0,io.delta:delta-spark_2.12:3.2.1 pyspark-shell"
         run: |
-          set -euxo pipefail
+          set -euo pipefail
 
           poetry run pytest --cov-config=.coveragerc --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=term-missing:skip-covered | tee pytest-coverage.txt
       - name: Publish Code Coverage


### PR DESCRIPTION
## Summary

Removes the `-x` flag from `set -euxo pipefail` to prevent secrets from being printed in GitHub Actions logs.

The `-x` flag causes bash to print each command before executing it, which can expose secret values that are passed as environment variables or arguments.

## Related Issue

Closes SneaksAndData/terraform#7626

## Changes

- Replaced `set -euxo pipefail` with `set -euo pipefail` in affected workflow files
